### PR TITLE
Add zone age logic and responsive UI

### DIFF
--- a/app/api/zones/route.ts
+++ b/app/api/zones/route.ts
@@ -1,6 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+interface ZoneRecord {
+  createdAt: Date
+  [key: string]: unknown
+}
+
+function zoneColor(createdAt: Date): string {
+  const weeks = (Date.now() - createdAt.getTime()) / (1000 * 60 * 60 * 24 * 7)
+  if (weeks >= 12) return 'green'
+  if (weeks >= 6) return 'yellow'
+  return 'red'
+}
+
 export async function POST(req: NextRequest) {
   try {
     const data = await req.json()
@@ -8,16 +20,17 @@ export async function POST(req: NextRequest) {
     if (!points || !Array.isArray(points)) {
       return NextResponse.json({ error: 'Invalid points' }, { status: 400 })
     }
-    const zone = await prisma.zone.create({
+    const zone: ZoneRecord = await prisma.zone.create({
       data: { points, description }
     })
-    return NextResponse.json(zone)
+    return NextResponse.json({ ...zone, color: zoneColor(zone.createdAt) })
   } catch {
     return NextResponse.json({ error: 'Server error' }, { status: 500 })
   }
 }
 
 export async function GET() {
-  const zones = await prisma.zone.findMany()
-  return NextResponse.json(zones)
+  const zones: ZoneRecord[] = await prisma.zone.findMany()
+  const result = zones.map((z: ZoneRecord) => ({ ...z, color: zoneColor(z.createdAt) }))
+  return NextResponse.json(result)
 }

--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -9,7 +9,7 @@ import { useMapEvents } from "react-leaflet"
 type MapProps = {
     location: number[]
     mode: "view" | "create" | undefined
-    zones: { points: number[][], description: string }[]
+    zones: { points: number[][], description: string, color: string }[]
     currentPoints: number[][]
     setCurrentPoints: Dispatch<SetStateAction<number[][]>>
 }
@@ -27,7 +27,7 @@ function CreateZoneHandler({ mode, setCurrentPoints }: { mode: "view" | "create"
 
 export default function MyMap(props: MapProps) {
     return (
-        <MapContainer className="w-[100%] h-128" center={{ lat: 51.505, lng: -0.09 }} zoom={13} scrollWheelZoom={true}>
+        <MapContainer className="w-full h-64 md:h-96" center={{ lat: 51.505, lng: -0.09 }} zoom={13} scrollWheelZoom={true}>
             <TileLayer
                 attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
                 url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -36,10 +36,10 @@ export default function MyMap(props: MapProps) {
             <LocationMarker />
             <CreateZoneHandler mode={props.mode} setCurrentPoints={props.setCurrentPoints} />
             {props.zones.map((zone, index) => (
-                <Polygon 
-                    key={index} 
-                    positions={zone.points as LatLngExpression[]} 
-                    pathOptions={{ color: 'blue', fillColor: 'blue', fillOpacity: 0.5 }}
+                <Polygon
+                    key={index}
+                    positions={zone.points as LatLngExpression[]}
+                    pathOptions={{ color: zone.color, fillColor: zone.color, fillOpacity: 0.5 }}
                 >
                     <Popup>{zone.description || "Без описания"}</Popup>
                 </Polygon>

--- a/app/components/select.tsx
+++ b/app/components/select.tsx
@@ -19,7 +19,7 @@ type ModeOption = {
 };
 
 export function SelectCity(props: SelectCityProps) {
-    return <>
+    return <div className="my-2">
         <Select onChange={
             (newLocation) => {
                 if (newLocation === null) {
@@ -27,9 +27,9 @@ export function SelectCity(props: SelectCityProps) {
                 }
                 props.setLocation(newLocation.value);
             }
-        } 
+        }
         options={city_options}/>
-    </>
+    </div>
 }
 
 export function SelectMode(props: SelectModeProps) {
@@ -40,14 +40,16 @@ export function SelectMode(props: SelectModeProps) {
     ];
     
     return (
+        <div className="my-2">
         <Select
             onChange={(newMode: ModeOption | null) => {
                 if (newMode === null) {
                     return;
                 }
                 props.setMode(newMode.value); // Теперь value — "view" | "create", ошибка ушла
-            }} 
+            }}
             options={options}
         />
+        </div>
     );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function MyPage() {
 
     const [location, setLocation] = useState<number[]>( [51.107883, 17.038538] ); // Default to Wrocław
     const [mapMode, setMapMode] = useState<"view" | "create">();
-    const [zones, setZones] = useState<{ points: number[][], description: string }[]>([]);
+    const [zones, setZones] = useState<{ points: number[][], description: string, color: string }[]>([]);
 
     useEffect(() => {
         fetch('/api/zones')
@@ -25,7 +25,7 @@ export default function MyPage() {
     const [currentPoints, setCurrentPoints] = useState<number[][]>([]);
     const [description, setDescription] = useState<string>("");
 
-    return <div>
+    return <div className="p-4 flex flex-col gap-4 max-w-screen-md mx-auto">
         <Map 
             location={location} 
             mode={mapMode} 
@@ -36,14 +36,16 @@ export default function MyPage() {
         <SelectCity setLocation={setLocation}/>
         <SelectMode setMode={setMapMode}/>
         {mapMode === "create" && (
-            <div>
-                <input 
-                    type="text" 
-                    value={description} 
-                    onChange={(e) => setDescription(e.target.value)} 
+            <div className="flex flex-col gap-2">
+                <input
+                    className="border p-2 rounded"
+                    type="text"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
                     placeholder="Введите описание зоны"
                 />
                 <button
+                    className="bg-blue-600 text-white py-2 px-4 rounded"
                     onClick={async () => {
                         if (currentPoints.length >= 3) {
                             const res = await fetch('/api/zones', {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,5 +11,6 @@ model Zone {
   id          Int      @id @default(autoincrement())
   points      Json
   description String
+  createdAt   DateTime @default(now())
 }
 


### PR DESCRIPTION
## Summary
- store creation date for zones
- compute zone color on backend depending on age
- show polygons with dynamic color
- improve map size and forms for mobile

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm install` *(fails: Failed to fetch prisma binaries)*
- `npx prisma generate` *(fails: 403 Forbidden to binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_b_68823cacc54c832788d0e0ca6f226163