### PR TITLE
feat: add zone duration

### DIFF
--- a/app/api/zones/route.ts
+++ b/app/api/zones/route.ts
@@ -5,6 +5,8 @@ import { authOptions } from '@/lib/auth'
 
 interface ZoneRecord {
   createdAt: Date
+  duration?: number
+  durationUnit?: string
   [key: string]: unknown
 }
 
@@ -22,13 +24,19 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
     const data = await req.json()
-    const { points, description } = data
+    const { points, description, duration, durationUnit } = data
     if (!points || !Array.isArray(points)) {
       return NextResponse.json({ error: 'Invalid points' }, { status: 400 })
     }
     const appendedDesc = `${description} Od: ${session.user?.name ?? ''} ${new Date().toLocaleDateString('pl-PL')}`
     const zone: ZoneRecord = await prisma.zone.create({
-      data: { points, description: appendedDesc, user: { connect: { id: Number(session.user.id) } } }
+      data: {
+        points,
+        description: appendedDesc,
+        duration,
+        durationUnit,
+        user: { connect: { id: Number(session.user.id) } }
+      }
     })
     return NextResponse.json({ ...zone, color: zoneColor(zone.createdAt) })
   } catch {

--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -6,10 +6,18 @@ import { useEffect, useState, Dispatch, SetStateAction, useRef } from "react"
 import { LatLng, LatLngExpression } from "leaflet"
 import { useMapEvents } from "react-leaflet"
 
+export type Zone = {
+    points: number[][]
+    description: string
+    color: string
+    duration?: number
+    durationUnit?: 'days' | 'weeks' | 'months'
+}
+
 type MapProps = {
     location: number[]
     mode: "view" | "create" | undefined
-    zones: { points: number[][], description: string, color: string }[]
+    zones: Zone[]
     currentPoints: number[][]
     setCurrentPoints: Dispatch<SetStateAction<number[][]>>
 }

--- a/app/map.tsx
+++ b/app/map.tsx
@@ -6,6 +6,7 @@ import { SelectCity, SelectMode } from './components/select'
 import { useSession, signIn, signOut } from 'next-auth/react'
 import Link from 'next/link'
 import { Session } from 'next-auth'
+import type { Zone } from './components/map'
 
 export default function MyPage() {
     const { data: session } = useSession()
@@ -20,15 +21,17 @@ export default function MyPage() {
 
     const [location, setLocation] = useState<number[]>( [52.237049, 21.017532] ); // Default to Poland
     const [mapMode, setMapMode] = useState<"view" | "create">();
-    const [zones, setZones] = useState<{ points: number[][], description: string, color: string }[]>([]);
+    const [zones, setZones] = useState<Zone[]>([]);
 
     useEffect(() => {
         fetch('/api/zones')
             .then(res => res.json())
-            .then(data => setZones(data));
+            .then(data => setZones(data as Zone[]));
     }, []);
     const [currentPoints, setCurrentPoints] = useState<number[][]>([]);
     const [description, setDescription] = useState<string>("");
+    const [duration, setDuration] = useState<number>(1);
+    const [durationUnit, setDurationUnit] = useState<'days' | 'weeks' | 'months'>('days');
 
     return <div className="p-4 flex flex-col gap-4 max-w-screen-md mx-auto">
         <div className="self-end flex gap-4">
@@ -58,6 +61,24 @@ export default function MyPage() {
                     onChange={(e) => setDescription(e.target.value)}
                     placeholder="Wpisz opis strefy"
                 />
+                <div className="flex gap-2">
+                    <input
+                        className="border p-2 rounded w-full"
+                        type="number"
+                        value={duration}
+                        onChange={(e) => setDuration(Number(e.target.value))}
+                        min={1}
+                    />
+                    <select
+                        className="border p-2 rounded"
+                        value={durationUnit}
+                        onChange={(e) => setDurationUnit(e.target.value as 'days' | 'weeks' | 'months')}
+                    >
+                        <option value="days">Dni</option>
+                        <option value="weeks">Tygodnie</option>
+                        <option value="months">Miesiące</option>
+                    </select>
+                </div>
                 <button
                     className="btn-primary"
                     onClick={async () => {
@@ -65,13 +86,15 @@ export default function MyPage() {
                             const res = await fetch('/api/zones', {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ points: currentPoints, description })
+                                body: JSON.stringify({ points: currentPoints, description, duration, durationUnit })
                             })
                             if (res.ok) {
                                 const newZone = await res.json()
                                 setZones([...zones, newZone])
                                 setCurrentPoints([])
                                 setDescription("")
+                                setDuration(1)
+                                setDurationUnit('days')
                             } else {
                                 alert('got error: ' + res.statusText)
                             }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,8 @@ model Zone {
   points      Json
   description String
   createdAt   DateTime @default(now())
+  duration     Int?
+  durationUnit String?
   user        User?    @relation(fields: [userId], references: [id])
   userId      Int?
 }


### PR DESCRIPTION
## Summary
- allow selecting a zone's duration with a numeric input and unit dropdown
- store `duration` and `durationUnit` for zones in the API and Prisma schema

## Testing
- `npx prisma generate`
- `npm test` (fails: missing script)
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Geist` from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_b_688f76243f0483329018e25685580fc1