### PR TITLE
Include zone creator in popup

### DIFF
--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -5,12 +5,20 @@ import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility
 import { useEffect, useState, Dispatch, SetStateAction, useRef } from "react"
 import { LatLng, LatLngExpression } from "leaflet"
 import { useMapEvents } from "react-leaflet"
-import { User } from "@prisma/client"
 
 type MapProps = {
     location: number[]
     mode: "view" | "create" | undefined
-    zones: { points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: User }[]
+    zones: {
+        points: number[][]
+        name: string
+        hoursFR: number
+        fullPZ: number
+        pz35Plus: number
+        efficiency: number
+        color: string
+        user: { name: string }
+    }[]
     currentPoints: number[][]
     setCurrentPoints: Dispatch<SetStateAction<number[][]>>
 }

--- a/app/map.tsx
+++ b/app/map.tsx
@@ -20,7 +20,7 @@ export default function MyPage() {
 
     const [location, setLocation] = useState<number[]>( [52.237049, 21.017532] ); // Default to Poland
     const [mapMode, setMapMode] = useState<"view" | "create">();
-    const [zones, setZones] = useState<{ points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string }[]>([]);
+    const [zones, setZones] = useState<{ points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: { name: string } }[]>([]);
 
     useEffect(() => {
         fetch('/api/zones')


### PR DESCRIPTION
## Summary
- show zone creator's name in map popups
- return zone creator from API when creating or listing zones

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch Geist from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_6890911983c483328c99c75cd9bf216e