### PR TITLE
Include user name in zone data

### DIFF
--- a/app/api/zones/route.ts
+++ b/app/api/zones/route.ts
@@ -38,7 +38,14 @@ export async function POST(req: NextRequest) {
         pz35Plus,
         efficiency,
         user: { connect: { id: Number(session.user.id) } }
-      }
+      },
+      include: {
+        user: {
+          select: {
+            name: true,
+          },
+        },
+      },
     })
     return NextResponse.json({ ...zone, color: zoneColor(zone.createdAt) })
   } catch {

--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -5,12 +5,11 @@ import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility
 import { useEffect, useState, Dispatch, SetStateAction, useRef } from "react"
 import { LatLng, LatLngExpression } from "leaflet"
 import { useMapEvents } from "react-leaflet"
-import { User } from "@prisma/client"
 
 type MapProps = {
     location: number[]
     mode: "view" | "create" | undefined
-    zones: { points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: User }[]
+    zones: { points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: { name: string } }[]
     currentPoints: number[][]
     setCurrentPoints: Dispatch<SetStateAction<number[][]>>
 }

--- a/app/map.tsx
+++ b/app/map.tsx
@@ -20,7 +20,7 @@ export default function MyPage() {
 
     const [location, setLocation] = useState<number[]>( [52.237049, 21.017532] ); // Default to Poland
     const [mapMode, setMapMode] = useState<"view" | "create">();
-    const [zones, setZones] = useState<{ points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string }[]>([]);
+    const [zones, setZones] = useState<{ points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: { name: string } }[]>([]);
 
     useEffect(() => {
         fetch('/api/zones')


### PR DESCRIPTION
## Summary
- return user name when creating zones
- type zones with user name in map components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68909369daf8833298155f5550c3007f