### PR TITLE
Add zone deletion and map navigation

### DIFF
--- a/app/admin/zones/zones.tsx
+++ b/app/admin/zones/zones.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import trashIcon from "@/public/trash.svg"
 export default function Zones() {
-    const [zones, setZones] = useState<{ 
+    const [zones, setZones] = useState<{
+        id: number,
         points: number[][],
         createdAt: Date,
         name: string,
@@ -23,8 +25,8 @@ export default function Zones() {
     return (
         <div className="flex flex-col items-center gap-6">
             {zones.map((zone) => (
-                <div 
-                    key={zone.createdAt.toString()} 
+                <div
+                    key={zone.id}
                     className="flex justify-between items-stretch border rounded-2xl p-4 shadow-md dark:bg-[#181818] border-[#818181] relative w-full max-w-xl"
                 >
                     {/* LEFT SIDE: Info */}
@@ -41,8 +43,23 @@ export default function Zones() {
                         <p className="text-sm text-gray-500">{formatDate(new Date(zone.createdAt))}</p>
                         <h1 className="text-lg font-bold">{zone.name}</h1>
                         <div className="flex ml-6 flex-row gap-4 items-right">
-                            <a className="text-primary cursor-pointer antialiased font-medium">Pokaż strefę</a>
-                            <Image className="cursor-pointer" color="#1CABE2" src={trashIcon} alt="delete zone" width={24} height={24}/>
+                            <Link className="text-primary cursor-pointer antialiased font-medium" href={`/map?zoneId=${zone.id}`}>Pokaż strefę</Link>
+                            <Image
+                                className="cursor-pointer"
+                                color="#1CABE2"
+                                src={trashIcon}
+                                alt="delete zone"
+                                width={24}
+                                height={24}
+                                onClick={async () => {
+                                    const res = await fetch(`/api/zones?id=${zone.id}`, {
+                                        method: 'DELETE'
+                                    });
+                                    if (res.ok) {
+                                        setZones(prev => prev.filter(z => z.id !== zone.id));
+                                    }
+                                }}
+                            />
                         </div>
                     </div>
                 </div>

--- a/app/api/zones/route.ts
+++ b/app/api/zones/route.ts
@@ -66,3 +66,22 @@ export async function GET() {
   const result = zones.map((z: Zone) => ({ ...z, color: zoneColor(z.createdAt) }))
   return NextResponse.json(result)
 }
+
+export async function DELETE(req: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const id = req.nextUrl.searchParams.get('id')
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+  }
+
+  try {
+    await prisma.zone.delete({ where: { id: Number(id) } })
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -9,7 +9,7 @@ import { useMapEvents } from "react-leaflet"
 type MapProps = {
     location: number[]
     mode: "view" | "create" | undefined
-    zones: { points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: { name: string } }[]
+    zones: { id: number, points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: { name: string } }[]
     currentPoints: number[][]
     setCurrentPoints: Dispatch<SetStateAction<number[][]>>
 }
@@ -35,9 +35,9 @@ export default function MyMap(props: MapProps) {
             <FlyTo location={props.location} />
             <LocationMarker />
             <CreateZoneHandler mode={props.mode} setCurrentPoints={props.setCurrentPoints} />
-            {props.zones.map((zone, index) => (
+            {props.zones.map((zone) => (
                 <Polygon
-                    key={index}
+                    key={zone.id}
                     positions={zone.points as LatLngExpression[]}
                     pathOptions={{ color: zone.color, fillColor: zone.color, fillOpacity: 0.5 }}
                 >

--- a/app/map.tsx
+++ b/app/map.tsx
@@ -6,6 +6,7 @@ import { SelectCity, SelectMode } from './components/select'
 import { useSession, signIn, signOut } from 'next-auth/react'
 import Link from 'next/link'
 import { Session } from 'next-auth'
+import { useSearchParams } from 'next/navigation'
 
 export default function MyPage() {
     const { data: session } = useSession()
@@ -20,13 +21,26 @@ export default function MyPage() {
 
     const [location, setLocation] = useState<number[]>( [52.237049, 21.017532] ); // Default to Poland
     const [mapMode, setMapMode] = useState<"view" | "create">();
-    const [zones, setZones] = useState<{ points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: { name: string } }[]>([]);
+    const [zones, setZones] = useState<{ id: number, points: number[][], name: string, hoursFR: number, fullPZ: number, pz35Plus: number, efficiency: number, color: string, user: { name: string } }[]>([]);
+    const searchParams = useSearchParams();
+    const zoneIdParam = searchParams.get('zoneId');
 
     useEffect(() => {
         fetch('/api/zones')
             .then(res => res.json())
             .then(data => setZones(data));
     }, []);
+
+    useEffect(() => {
+        if (zoneIdParam && zones.length > 0) {
+            const zone = zones.find(z => z.id === Number(zoneIdParam));
+            if (zone) {
+                const lat = zone.points.reduce((sum, p) => sum + p[0], 0) / zone.points.length;
+                const lng = zone.points.reduce((sum, p) => sum + p[1], 0) / zone.points.length;
+                setLocation([lat, lng]);
+            }
+        }
+    }, [zoneIdParam, zones]);
     const [currentPoints, setCurrentPoints] = useState<number[][]>([]);
     const [name, setName] = useState<string>("");
     const [hoursFR, setHoursFR] = useState<string>("");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,11 +2,12 @@
 import { SessionProvider } from "next-auth/react";
 import MyMap from "./components/map";
 import MyPage from "./map";
+import { Suspense } from "react";
 
 export default function MainPage() {
     return (
         <SessionProvider>
-            <MyPage/>
+            <Suspense><MyPage/></Suspense>
         </SessionProvider>
     )
 }


### PR DESCRIPTION
## Summary
- enable admin deletion of zones through new DELETE `/api/zones` endpoint
- link each admin zone entry to the map for direct viewing and allow in-page deletion
- center map on specified zone when `zoneId` query parameter is present

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890c3991f548332bc1c7b5581bc2513