### PR TITLE
Refactor: add /map route for zone navigation

### DIFF
--- a/app/MapPage.tsx
+++ b/app/MapPage.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link'
 import { Session } from 'next-auth'
 import { useSearchParams } from 'next/navigation'
 
-export default function MyPage() {
+export default function MapPage() {
     const { data: session } = useSession()
     const Map = useMemo(() => dynamic(
         () => import('@/app/components/map'),

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+import { SessionProvider } from "next-auth/react";
+import MapPage from "../MapPage";
+import { Suspense } from "react";
+
+export default function MapRoute() {
+  return (
+    <SessionProvider>
+      <Suspense><MapPage /></Suspense>
+    </SessionProvider>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,12 @@
 'use client'
 import { SessionProvider } from "next-auth/react";
-import MyMap from "./components/map";
-import MyPage from "./map";
+import MapPage from "./MapPage";
 import { Suspense } from "react";
 
 export default function MainPage() {
     return (
         <SessionProvider>
-            <Suspense><MyPage/></Suspense>
+            <Suspense><MapPage/></Suspense>
         </SessionProvider>
     )
 }


### PR DESCRIPTION
## Summary
- create `/map` route and wrap map with `SessionProvider`
- reuse new `MapPage` component for both the root and `/map` routes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890c7afb16c8332920f556f66b104bf