### PR TITLE
Prevent negative values when creating zones

### DIFF
--- a/app/MapPage.tsx
+++ b/app/MapPage.tsx
@@ -93,6 +93,7 @@ export default function MapPage() {
                 <input
                     className="border p-2 rounded"
                     type="number"
+                    min="0"
                     value={hoursFR}
                     onChange={(e) => setHoursFR(e.target.value)}
                     placeholder="Ile godzin FR pracowali"
@@ -100,6 +101,7 @@ export default function MapPage() {
                 <input
                     className="border p-2 rounded"
                     type="number"
+                    min="0"
                     value={fullPZ}
                     onChange={(e) => setFullPZ(e.target.value)}
                     placeholder="Ile PZ pełnych"
@@ -107,6 +109,7 @@ export default function MapPage() {
                 <input
                     className="border p-2 rounded"
                     type="number"
+                    min="0"
                     value={pz35Plus}
                     onChange={(e) => setPz35Plus(e.target.value)}
                     placeholder="Ile PZ 35+"
@@ -116,6 +119,7 @@ export default function MapPage() {
                     <input
                         className="border p-2 rounded w-20"
                         type="number"
+                        min="0"
                         value={yellowValue}
                         onChange={(e) => setYellowValue(e.target.value)}
                         placeholder="Ilość"
@@ -144,6 +148,7 @@ export default function MapPage() {
                     <input
                         className="border p-2 rounded w-20"
                         type="number"
+                        min="0"
                         value={greenValue}
                         onChange={(e) => setGreenValue(e.target.value)}
                         placeholder="Ilość"
@@ -177,12 +182,12 @@ export default function MapPage() {
                                 body: JSON.stringify({
                                     points: currentPoints,
                                     name,
-                                    hoursFR: Number(hoursFR),
-                                    fullPZ: Number(fullPZ),
-                                    pz35Plus: Number(pz35Plus),
-                                    yellowDuration: Number(yellowValue),
+                                    hoursFR: Math.max(0, Number(hoursFR)),
+                                    fullPZ: Math.max(0, Number(fullPZ)),
+                                    pz35Plus: Math.max(0, Number(pz35Plus)),
+                                    yellowDuration: Math.max(0, Number(yellowValue)),
                                     yellowUnit,
-                                    greenDuration: Number(greenValue),
+                                    greenDuration: Math.max(0, Number(greenValue)),
                                     greenUnit
                                 })
                             })

--- a/app/api/zones/route.ts
+++ b/app/api/zones/route.ts
@@ -38,18 +38,23 @@ export async function POST(req: NextRequest) {
     if (!points || !Array.isArray(points)) {
       return NextResponse.json({ error: 'Invalid points' }, { status: 400 })
     }
-    const efficiencyStr = (hoursFR ? fullPZ / hoursFR : 0).toFixed(2)
+    const hoursFRNum = Math.max(0, Number(hoursFR))
+    const fullPZNum = Math.max(0, Number(fullPZ))
+    const pz35PlusNum = Math.max(0, Number(pz35Plus))
+    const yellowDurationNum = Math.max(0, Number(yellowDuration))
+    const greenDurationNum = Math.max(0, Number(greenDuration))
+    const efficiencyStr = (hoursFRNum ? fullPZNum / hoursFRNum : 0).toFixed(2)
     const efficiency = +efficiencyStr
     const appendedName = `${name}`
-    const yellowStatusDate = calculateStatusDate(Number(yellowDuration), yellowUnit)
-    const greenStatusDate = calculateStatusDate(Number(greenDuration), greenUnit)
+    const yellowStatusDate = calculateStatusDate(yellowDurationNum, yellowUnit)
+    const greenStatusDate = calculateStatusDate(greenDurationNum, greenUnit)
     const zone: ZoneRecord = await prisma.zone.create({
       data: {
         points,
         name: appendedName,
-        hoursFR,
-        fullPZ,
-        pz35Plus,
+        hoursFR: hoursFRNum,
+        fullPZ: fullPZNum,
+        pz35Plus: pz35PlusNum,
         efficiency,
         yellowStatusDate,
         greenStatusDate,


### PR DESCRIPTION
## Summary
- disallow negative hours, PZ counts and duration values on the zone creation form
- sanitize zone values on the server so they cannot drop below zero

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6891eb9e8a0c8332953143bd284dff9e