### PR TITLE
Show red marker for first zone click

### DIFF
--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -1,4 +1,4 @@
-import { MapContainer, Marker, Popup, TileLayer, useMap, Polyline, Polygon } from "react-leaflet"
+import { MapContainer, Marker, Popup, TileLayer, useMap, Polyline, Polygon, CircleMarker } from "react-leaflet"
 import "leaflet/dist/leaflet.css"
 import "leaflet-defaulticon-compatibility"
 import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css"
@@ -55,10 +55,18 @@ export default function MyMap(props: MapProps) {
                     </Popup>
                 </Polygon>
             ))}
-            {props.mode === "create" && props.currentPoints.length > 0 && (
-                <Polyline 
-                    positions={props.currentPoints as LatLngExpression[]} 
-                    pathOptions={{ color: 'red' }} 
+            {props.mode === "create" && props.currentPoints.map((point, index) => (
+                <CircleMarker
+                    key={index}
+                    center={point as LatLngExpression}
+                    radius={5}
+                    pathOptions={{ color: 'red', fillColor: 'red' }}
+                />
+            ))}
+            {props.mode === "create" && props.currentPoints.length > 1 && (
+                <Polyline
+                    positions={props.currentPoints as LatLngExpression[]}
+                    pathOptions={{ color: 'red' }}
                 />
             )}
         </MapContainer>


### PR DESCRIPTION
## Summary
- show a red circle marker on each point when creating a zone so first click is visible
- keep polyline rendering for multiple points

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6891f827f90c833280154e97ccd792b7