### PR TITLE
Add city and mode toggles for map

### DIFF
--- a/app/MapPage.tsx
+++ b/app/MapPage.tsx
@@ -20,9 +20,9 @@ export default function MapPage() {
 
 
 
-    const [location, setLocationState] = useState<number[]>( [52.237049, 21.017532] ); // Default to Poland
-    const [zoom, setZoom] = useState<number>(13);
-    const [mapMode, setMapMode] = useState<"view" | "create">();
+    const [location, setLocationState] = useState<number[]>([52.237049, 21.017532]); // Center of Poland
+    const [zoom, setZoom] = useState<number>(6); // Show whole Poland initially
+    const [mapMode, setMapMode] = useState<"view" | "create">("view");
 
     const setLocationAndZoom = (coords: number[], zoomLevel = 13) => {
         setLocationState(coords);
@@ -69,6 +69,7 @@ export default function MapPage() {
                 <button className="text-primary" onClick={() => signIn()}>Zaloguj się</button>
             )}
         </div>
+        <SelectMode setMode={setMapMode}/>
         <Map
             location={location}
 
@@ -78,9 +79,7 @@ export default function MapPage() {
             currentPoints={currentPoints}
             setCurrentPoints={setCurrentPoints}
         />
-        <SelectCity setLocation={(coords) => setLocationAndZoom(coords)}/>
-
-        <SelectMode setMode={setMapMode}/>
+        <SelectCity setLocation={(coords, zoom) => setLocationAndZoom(coords, zoom)}/>
         {mapMode === "create" && session && (
             <div className="flex flex-col gap-2">
                 <input

--- a/app/components/select.tsx
+++ b/app/components/select.tsx
@@ -1,58 +1,76 @@
-import Select from "react-select";
+import { useState } from "react";
 
-const city_options = [
-    {value: [51.107883, 17.038538], label: "Wrocław"},
-    {value: [52.237049, 21.017532], label: "Warszawa"}
-]
+// Coordinates for supported cities
+const cities: { name: string; coords: number[] }[] = [
+    { name: "Wrocław", coords: [51.107883, 17.038538] },
+    { name: "Warszawa", coords: [52.237049, 21.017532] },
+];
 
 type SelectCityProps = {
-    setLocation: (location: number[]) => void
-}
+    // Allows passing optional zoom level when changing location
+    setLocation: (location: number[], zoom?: number) => void;
+};
 
 type SelectModeProps = {
-    setMode: (mode: "view" | "create") => void
-}
-
-type ModeOption = {
-    value: "view" | "create";
-    label: string;
+    setMode: (mode: "view" | "create") => void;
 };
 
 export function SelectCity(props: SelectCityProps) {
-    return <div className="my-2 text-black">
-        <Select 
-        defaultValue={{value: [52.237049, 21.017532], label: "Polska"}}
-        onChange={
-            (newLocation) => {
-                if (newLocation === null) {
-                    return;
-                }
-                props.setLocation(newLocation.value);
-            }
+    const [selected, setSelected] = useState<string | null>(null);
+
+    const toggleCity = (city: string, coords: number[]) => {
+        if (selected === city) {
+            setSelected(null);
+            // Reset to whole Poland view
+            props.setLocation([52.237049, 21.017532], 6);
+        } else {
+            setSelected(city);
+            props.setLocation(coords, 13);
         }
-        options={city_options}/>
-    </div>
+    };
+
+    return (
+        <div className="flex gap-4 justify-center my-2">
+            {cities.map((city) => (
+                <label key={city.name} className="flex items-center gap-2">
+                    <input
+                        type="checkbox"
+                        checked={selected === city.name}
+                        onChange={() => toggleCity(city.name, city.coords)}
+                    />
+                    {city.name}
+                </label>
+            ))}
+        </div>
+    );
 }
 
 export function SelectMode(props: SelectModeProps) {
+    const [mode, setMode] = useState<"view" | "create">("view");
 
-    const options: ModeOption[] = [
-        { value: "view", label: "Przegląd" },
-        { value: "create", label: "Tworzenie" }
-    ];
-    
+    const handleClick = (newMode: "view" | "create") => {
+        setMode(newMode);
+        props.setMode(newMode);
+    };
+
     return (
-        <div className="my-2">
-        <Select
-            defaultValue={options[0]}
-            onChange={(newMode: ModeOption | null) => {
-                if (newMode === null) {
-                    return;
-                }
-                props.setMode(newMode.value); // Теперь value — "view" | "create", ошибка ушла
-            }}
-            options={options}
-        />
+        <div className="flex justify-center my-2">
+            <button
+                className={`px-4 py-2 border rounded-l ${
+                    mode === "create" ? "bg-primary text-white" : "bg-white text-black"
+                }`}
+                onClick={() => handleClick("create")}
+            >
+                Tworzenie
+            </button>
+            <button
+                className={`px-4 py-2 border rounded-r ${
+                    mode === "view" ? "bg-primary text-white" : "bg-white text-black"
+                }`}
+                onClick={() => handleClick("view")}
+            >
+                Przegląd
+            </button>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Add checkbox city selector under the map
- Replace react-select mode dropdown with two-sided toggle button
- Start map centered on Poland with view mode by default

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6892045a39e083329c2e8946c3a9a7e2