### PR TITLE
Restrict zone visibility for unauthenticated users

### DIFF
--- a/app/MapPage.tsx
+++ b/app/MapPage.tsx
@@ -34,10 +34,15 @@ export default function MapPage() {
     const zoneIdParam = searchParams.get('zoneId');
 
     useEffect(() => {
+        if (!session) {
+            setZones([])
+            return
+        }
         fetch('/api/zones')
-            .then(res => res.json())
-            .then(data => setZones(data));
-    }, []);
+            .then(res => res.ok ? res.json() : [])
+            .then(data => setZones(data))
+            .catch(() => setZones([]))
+    }, [session]);
 
     useEffect(() => {
         if (zoneIdParam && zones.length > 0) {

--- a/app/api/zones/route.ts
+++ b/app/api/zones/route.ts
@@ -75,6 +75,10 @@ export async function POST(req: NextRequest) {
 }
 
 export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const zones = await prisma.zone.findMany({
     include: {
       user: {


### PR DESCRIPTION
## Summary
- Hide map zones for visitors who are not logged in
- Require authentication for the `/api/zones` GET endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68920d796a64833291a88264ec90cc5d