### PR TITLE
Fix user list updates and enable admin editing

### DIFF
--- a/app/admin/users/UserItem.tsx
+++ b/app/admin/users/UserItem.tsx
@@ -1,0 +1,69 @@
+import { User } from "@prisma/client"
+import Image from "next/image"
+import trashIcon from "@/public/trash.svg"
+import { useState } from "react"
+
+export type UserItemProps = {
+  user: User
+  onDelete: (email: string) => void
+  onUpdate: (
+    originalEmail: string,
+    name: string,
+    email: string,
+    passwordChangeRequest: boolean
+  ) => Promise<string | undefined>
+}
+
+export default function UserItem({ user, onDelete, onUpdate }: UserItemProps) {
+  const [name, setName] = useState(user.name)
+  const [email, setEmail] = useState(user.email)
+  const [password, setPassword] = useState<string | null>(null)
+
+  const save = async () => {
+    const newPassword = await onUpdate(user.email, name, email, false)
+    if (newPassword) {
+      setPassword(newPassword)
+    } else {
+      setPassword(null)
+    }
+  }
+
+  const resetPassword = async () => {
+    const newPassword = await onUpdate(user.email, name, email, true)
+    if (newPassword) {
+      setPassword(newPassword)
+    }
+  }
+
+  return (
+    <div className="rounded border-1 border-[#818181] p-5 flex flex-col gap-2">
+      <input
+        className="border border-[#818181] p-1 rounded"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        className="border border-[#818181] p-1 rounded"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <div className="flex gap-2 items-center">
+        <button className="btn-primary" onClick={save}>
+          Zapisz
+        </button>
+        <button className="btn-primary" onClick={resetPassword}>
+          Resetuj hasło
+        </button>
+        <Image
+          width={24}
+          height={24}
+          alt="delete user"
+          src={trashIcon}
+          onClick={() => onDelete(user.email)}
+        />
+      </div>
+      {password && <div className="mt-2">Nowe hasło: {password}</div>}
+    </div>
+  )
+}
+

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -11,17 +11,20 @@ import { User } from "@prisma/client";
 export default function AdminUsersPage() {
   const [users, setUsers] = useState<User[]>([]);
   useEffect(() => {
-          fetch('/api/users')
-              .then(res => res.json())
-              .then(data => setUsers(data));
-      }, []);
+    async function loadUsers() {
+      const res = await fetch('/api/users')
+      const data = await res.json()
+      setUsers(data)
+    }
+    loadUsers()
+  }, [])
   return (
     <>
     <AdminNavbar/>
     <SessionProvider>
       <div className="flex flex-col items-center">
         <Link className="font-medium text-primary" href="/admin/users/create">Chcesz stworzyć konto?</Link>
-        <Users users={users}/>
+        <Users users={users} setUsers={setUsers} />
       </div>
     </SessionProvider>
     </>

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: NextRequest) {
   return NextResponse.json({ password: passwordPlain })
 }
 
-export async function GET(req: NextRequest) {
+export async function GET() {
   const session = await getServerSession(authOptions)
 
   if (!session || session.user.role !== 'ADMIN') {
@@ -42,36 +42,35 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const {originalEmail, name, email, passwordChangeRequest } = await req.json()
-  
+  const { originalEmail, name, email, passwordChangeRequest } = await req.json()
+
   if (passwordChangeRequest) {
     const passwordPlain = Math.random().toString(36).slice(-8)
     const password = await hash(passwordPlain, 10)
-    
-    const user = prisma.user.update({
+
+    await prisma.user.update({
       where: {
-        email: originalEmail
+        email: originalEmail,
       },
       data: {
         email: email,
         password: password,
-        name: name
-      }
+        name: name,
+      },
     })
 
-    return NextResponse.json({name: name, email: email, password: passwordPlain})
+    return NextResponse.json({ name: name, email: email, password: passwordPlain })
   } else {
-
-    const user = prisma.user.update({
-        where: {
-          email: originalEmail
-        },
-        data: {
-          email: email,
-          name: name
-        }
-      })
-    return NextResponse.json({name: name, email: email})
+    await prisma.user.update({
+      where: {
+        email: originalEmail,
+      },
+      data: {
+        email: email,
+        name: name,
+      },
+    })
+    return NextResponse.json({ name: name, email: email })
   }
 }
 
@@ -87,7 +86,7 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: 'Missing id' }, { status: 400 })
   }
 
-  const user = await prisma.user.delete({
+  await prisma.user.delete({
     where: {
       email: email
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@
 import type { Metadata } from "next";
 import { Geist} from "next/font/google";
 import "./globals.css";
-import { SessionProvider } from "next-auth/react";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",


### PR DESCRIPTION
## Summary
- fix users page to refresh list after deletions
- refactor admin users components and add inline user edit & password reset
- adjust users API for updates with optional password regeneration

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Geist` from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_b_6895dd8049848332b2a35c5af60ba2d0